### PR TITLE
Add img alt text so that link has discernible text

### DIFF
--- a/v2/templates/index.html
+++ b/v2/templates/index.html
@@ -36,7 +36,7 @@
       <ul class="projects">
         <li>
           <a href="https://github.com/wezm/feedlynx" class="no-border">
-            <img src="{{ config.base_url }}/images/feedlynx.svg" width="32" alt="">
+            <img src="{{ config.base_url }}/images/feedlynx.svg" width="32" alt="Feedlynx">
           </a>
           <a href="https://github.com/wezm/feedlynx">Feedlynx</a>
           <p>Collect links to read or watch later in an RSS feed.</p>


### PR DESCRIPTION
This PR adds "Feedlynx" `alt` text to the `img` so that the `<a>` that wraps it has link text because [Links must have discernible text](https://dequeuniversity.com/rules/axe/4.10/link-name). Alternatively, you could try merge the img link with the adjacent text link into 1 link or use `aria-label` on the img `<a>`.